### PR TITLE
fix: Make 'Upload Image' button open file dialog using react-dropzone open() method

### DIFF
--- a/client/src/pages/SubmitExpense.tsx
+++ b/client/src/pages/SubmitExpense.tsx
@@ -32,12 +32,13 @@ const SubmitExpense: React.FC = () => {
     }
   };
 
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+  const { getRootProps, getInputProps, isDragActive, open } = useDropzone({
     onDrop,
     accept: {
       'image/*': ['.jpeg', '.jpg', '.png', '.gif']
     },
-    multiple: false
+    multiple: false,
+    noClick: true, // Prevent default click-to-open
   });
 
   const capturePhoto = () => {
@@ -110,7 +111,10 @@ const SubmitExpense: React.FC = () => {
         <div className="flex space-x-4 mb-6">
           <button
             type="button"
-            onClick={() => setCaptureMode('upload')}
+            onClick={() => {
+              setCaptureMode('upload');
+              open(); // Open file dialog
+            }}
             className={`flex items-center space-x-2 px-4 py-2 rounded-lg ${
               captureMode === 'upload'
                 ? 'bg-blue-500 text-white'


### PR DESCRIPTION
This PR improves the user experience for uploading receipt images on the Submit Expense page. Now, clicking the 'Upload Image' button will immediately open the file dialog, using the open() method from react-dropzone. This matches user expectations and makes the upload process more intuitive.

- Uses react-dropzone's open() method
- Sets noClick: true to prevent the dropzone area from opening the dialog on click
- The dashed dropzone area still supports drag-and-drop

Closes # (if there is a related issue)